### PR TITLE
#163449437 Make the default location when the page loads Chicago 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "immutable": "^4.0.0-rc.12",
     "moment": "^2.22.2",
     "node-fetch": "^2.3.0",
+    "query-string": "^6.2.0",
     "react": "^16.6.3",
     "react-apollo": "^2.3.2",
     "react-dom": "^16.6.3",

--- a/src/components/SearchPage/index.js
+++ b/src/components/SearchPage/index.js
@@ -1,27 +1,39 @@
 import React, { Component } from 'react';
+import queryString from 'query-string';
 
 import { Query } from 'react-apollo';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { RESTAURANT_SEARCH_QUERY } from '../../graphql/queries';
 
 class SearchPage extends Component {
+  state = {
+    address: 'Chicago',
+  }
+
+  componentDidMount() {
+    const { location } = this.props;
+    const { search } = location;
+    const params = queryString.parse(search);
+    const address = params.address;
+    this.setState({
+      ...this.state,
+      address: address || 'Chicago',
+    });
+  }
+
   render() {
     return (
       // Variables can be either lat and lon OR address
       <Query
         query={RESTAURANT_SEARCH_QUERY}
         variables={{
-          address: 'Manhattan'
+          address: this.state,
         }}
       >
         {({ loading, error, data = {} }) => {
           if (loading) {
             return <CircularProgress />;
           }
-
-          console.log('DO SOMETHING SMART WITH THIS DATA');
-          console.log('data', data);
-          console.log('error', error);
 
           // Make sure we have data
           if (


### PR DESCRIPTION
#### Description
- Add implementation to search by accepting params from a query string
- Make the default location/address  Chicago

#### How to tests branch
- Make a local copy of the branch, run npm install and then npm start to start the app. 
- In the browser URL bar add ` /?address=your-address` to the path
**Note your-address:** A string representing the location you want to search (country)
- If the address value is provided it will be used for the search. If the address value is not provided or the address query is not present, the search will default to Chicago

#### Pivotal tracker story
https://www.pivotaltracker.com/story/show/163449437