### PR TITLE
# Make the restaurant title go to the rest page (/rest/:id)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "immutable": "^4.0.0-rc.12",
     "moment": "^2.22.2",
     "node-fetch": "^2.3.0",
+    "prop-types": "^15.7.2",
     "query-string": "^6.2.0",
     "react": "^16.6.3",
     "react-apollo": "^2.3.2",

--- a/src/components/SearchPage/ResturantCard.js
+++ b/src/components/SearchPage/ResturantCard.js
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Grade from '@material-ui/icons/Grade';
 import DirectionsWalk from '@material-ui/icons/DirectionsWalk';
 import Place from '@material-ui/icons/Place';
+import { Link } from 'react-router-dom';
 
 const styles = (theme) => ({
   card: {
@@ -38,6 +39,10 @@ const styles = (theme) => ({
     position: 'relative',
     top: '-5px',
     left: '3px',
+  },
+  link: {
+    textDecoration: 'none',
+    position:'relative',
   }
 });
 
@@ -46,11 +51,9 @@ const ResturantCard = (props) => {
   const { restDetails, showComplete } = props;
   const image = restDetails.images;
   let { distance, title, address } = restDetails;
-  let titleCursor = 'default';
   let addressCursor = 'default';
   if (title.length > 20) {
     title = `${title.substr(0, 20)}...`;
-    titleCursor = 'pointer';
   }
 
   if (address.length > 35) {
@@ -58,24 +61,22 @@ const ResturantCard = (props) => {
     addressCursor = 'pointer';
   }
   distance = distance ? distance.toPrecision(3) : distance;
-  console.log(restDetails);
   return (
     <div variant="contained" className={`${classes.content}`}>
       <Card className={classes.card}>
         <CardContent className={classes.content}>
-          <Fragment>
+          <Link className={classes.link} to={`rest/${restDetails.id}`}>
             <Place color="primary" />
             <Typography
               variant="title"
               color="textSecondary"
-              style={{cursor: titleCursor}}
               onMouseDown={
                 (event) => showComplete(event, restDetails, 'title')}
               className={classes.titleTypograph}
             >
-              { title}
+              {title}
             </Typography>
-          </Fragment>
+          </Link>
           <Typography variant="subtitle3" color="textPrimary">
             {restDetails.cuisine}
           </Typography>


### PR DESCRIPTION
#### What does this pull request do?
- Add implementation to make the restaurant title redirect to the rest page.

#### Description of tasks to be completed
- import Link component from react-router-dom
- Apply the Link component to every restaurant card and let it direct to 'rest/restId'

#### Relevant Pivotal tracker story
# 163449367